### PR TITLE
Apply fixes for LiveViewTest with uploads (#1409)

### DIFF
--- a/lib/phoenix_live_view/test/live_view_test.ex
+++ b/lib/phoenix_live_view/test/live_view_test.ex
@@ -1368,7 +1368,7 @@ defmodule Phoenix.LiveViewTest do
 
   ## Examples
 
-      avatar = file_input(lv, "form", :avatar, %{name: ..., ...})
+      avatar = file_input(lv, "#my-form-id", :avatar, [%{name: ..., ...}, ...])
       assert {:ok, %{ref: _ref, config: %{chunk_size: _}}} = preflight_upload(avatar)
   """
   def preflight_upload(%Upload{} = upload) do

--- a/lib/phoenix_live_view/test/upload_client.ex
+++ b/lib/phoenix_live_view/test/upload_client.ex
@@ -65,8 +65,19 @@ defmodule Phoenix.LiveViewTest.UploadClient do
     {:reply, pids, state}
   end
 
-  def handle_call({:chunk, entry_name, percent, proxy_pid, element}, from, state) do
-    {:reply, :ok, chunk_upload(state, from, entry_name, percent, proxy_pid, element)}
+  def handle_call({:chunk, entry_name, percent, proxy_pid, element}, _from, state) do
+    ref = make_ref()
+    new_state = chunk_upload(state, {self(), ref}, entry_name, percent, proxy_pid, element)
+
+    # We need to wait for ClientProxy to sync the
+    # :upload_progress before replying to the caller,
+    # otherwise the proxy's reply will race our own.
+    receive do
+      {^ref, {:ok, _}} ->
+        {:reply, :ok, new_state}
+    after
+      1000 -> exit(:timeout)
+    end
   end
 
   def handle_call({:simulate_attacker_chunk, entry_name, chunk}, _from, state) do
@@ -180,5 +191,9 @@ defmodule Phoenix.LiveViewTest.UploadClient do
       {:ok, entry} -> entry
       :error ->  raise "no file input with name \"#{name}\" found in #{inspect(state.entries)}"
     end
+  end
+
+  def handle_info(:garbage_collect, state) do
+    {:noreply, state}
   end
 end


### PR DESCRIPTION
* Fix LiveViewTest.preflight_upload/1 example

* Handle garbage_collect messages

* Ensure LiveViewTest.render_upload/3 waits for progress sync

Occasionally, mostly in CI, the ClientProxy reply would "win"
the race with the UploadClient to reply for a chunk, causing
a MatchError.

This change ensures the :chunk call will wait for the proxy
or timeout before replying.

Co-authored-by: Jason Goldberger <jasongoldberger@gmail.com>