### PR TITLE
Suggest option to use `phx-track-static` (#1416)

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -214,6 +214,13 @@ The layout given to `put_root_layout` must use `<%= @inner_content %>` instead o
 
 Once you have specified a root layout, "app.html.eex" will be rendered within your root layout for all non-LiveViews. You may also optionally define a "live.html.leex" layout to be used across all LiveViews, as we will describe in the next section.
 
+Optionally, you can add a [`phx-track-static`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#static_changed?/1) to all `script` and `link` elements that uses `src` and `href`. This way you can detect when new assets have been deployed by calling `static_changed?`.
+
+```elixir
+<link phx-track-static rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
+<script phx-track-static defer type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
+```
+
 ## phx.gen.live support
 
 While the above instructions are enough to install LiveView in a Phoenix app, if you want to use the `phx.gen.live` generators that come as part of Phoenix v1.5, you need to do one more change, as those generators assume your application was created with `mix phx.new --live`.


### PR DESCRIPTION
In order to keep up with the default install from `mix phx.new --live`,
explain the possibility of usage of `phx-track-static` which improves
the DX (Developer Experience) even more.